### PR TITLE
#24 - remapeia volume de linear para exponencial

### DIFF
--- a/dub.cpp
+++ b/dub.cpp
@@ -79,7 +79,8 @@ void KnobHandlerDaisy::UpdateAll()
     lfo->RateValue  = hw.adc.GetFloat(RateKnob);
 
     // OutAmp volume knob
-    out_amp->VolumeValue = hw.adc.GetFloat(VolumeKnob);
+    out_amp->VolumeValue
+        = fmap(hw.adc.GetFloat(VolumeKnob), 0.f, 1.f, Mapping::EXP);
 }
 // KnobHandler functions
 


### PR DESCRIPTION
## Descrição

A única mudança feita foi remapear o mapeamento do volume de linear para exponencial diretamente na função `KnobHandlerDaisy::UpdateAll()` ao invés de fazer o mapeamento na `AudioCallback`.

## Testagem

É possível rodar esse código no hardware, mas alguns outros parâmetros podem não estar funcionando - funcionarão perfeitamente após mergear os outros PRs.

Verifique se o deslize do knob de volume está satisfatório.

## Issues relacionadas

Closes #24 