### PR TITLE
#28 - Diminuir a frequência mínima inferior do Rate

### DIFF
--- a/dub.h
+++ b/dub.h
@@ -21,7 +21,7 @@ using namespace daisysp;
 #define LFO_1_WAVEFORM Oscillator::WAVE_SQUARE
 #define LFO_2_WAVEFORM Oscillator::WAVE_SAW
 #define LFO_3_WAVEFORM Oscillator::WAVE_RAMP
-#define LFO_MIN_FREQ 1.0f
+#define LFO_MIN_FREQ 0.1f
 #define LFO_MAX_FREQ 20.0f
 
 #define VCF_FILTER OnePole::FILTER_MODE_LOW_PASS


### PR DESCRIPTION
## Descrição

Esta PR altera a frequência mínima dos LFOs de 1Hz para 0.1Hz.

## Testagem

Mexa no knob de rate e veja se está confortável. A frequência mínima está satisfatória?

## Issues relacionadas

Closes #28 
