### PR TITLE
#31 - Ajustar frequência mínima e máxima do filtro

### DIFF
--- a/dub.h
+++ b/dub.h
@@ -25,7 +25,7 @@ using namespace daisysp;
 #define LFO_MAX_FREQ 20.0f
 
 #define VCF_FILTER OnePole::FILTER_MODE_LOW_PASS
-#define VCF_MIN_FREQ 24.0f
+#define VCF_MIN_FREQ 120.0f
 #define VCF_MAX_FREQ 15000.0f
 
 DaisySeed hw;


### PR DESCRIPTION
## Descrição

Esta PR apenas aumenta a frequência mínima do filtro de 24Hz para 120Hz. A frequência máxima não foi alterada.

Com 120Hz de mínimo, o som fica bem opaco, mas ainda sim é possível ouvir as pancadas dos pulsos. A máxima se manteve em 15kHz pois está atrelado à frequência máxima que a classe Vcf consegue suportar.

## Testagem

Mexa o knob de sweep e teste com várias configurações dos outros parâmetros.

## Issues relacionadas

Closes #31 