### PR TITLE
#34 - Criar terceiro LED que indica frequência e forma do LFO

### DIFF
--- a/dub.cpp
+++ b/dub.cpp
@@ -79,7 +79,8 @@ void KnobHandlerDaisy::UpdateAll()
     lfo->RateValue  = hw.adc.GetFloat(RateKnob);
 
     // OutAmp volume knob
-    out_amp->VolumeValue = hw.adc.GetFloat(VolumeKnob);
+    out_amp->VolumeValue
+        = fmap(hw.adc.GetFloat(VolumeKnob), 0.f, 1.f, Mapping::EXP);
 }
 // KnobHandler functions
 

--- a/dub.cpp
+++ b/dub.cpp
@@ -42,6 +42,7 @@ Vcf*           vcf;
 OutAmp*        out_amp;
 GPIO           led_sweep;
 GPIO           led_bank;
+Led            led_lfo;
 bool           test = false; // Used to test the Sweep LED
 //Initialize led1. We'll plug it into pin 28.
 //false here indicates the value is uninverted
@@ -448,6 +449,7 @@ void AudioCallback(AudioHandle::InputBuffer  in,
         bool  pressed   = triggers->Pressed();
         float sweepVal  = hw.adc.GetFloat(SweepKnob);
 
+
         // Reset envelope and LFO on trigger
         if(triggered)
         {
@@ -563,6 +565,11 @@ void AudioCallback(AudioHandle::InputBuffer  in,
         vco_output = vco->Process();
         output *= vco_output;
 
+        // -- LFO LED control ---
+        led_lfo.Set((lfo_output.first * 0.5f + 0.5f) * adsr_output);
+
+        led_lfo.Update();
+
         // --- Apply VCF low-pass filter ---
         output = vcf->Process(output);
 
@@ -584,6 +591,7 @@ int main(void)
     BLOCK_SIZE  = hw.AudioBlockSize();
     led_sweep.Init(daisy::seed::D27, GPIO::Mode::OUTPUT);
     led_bank.Init(daisy::seed::D28, GPIO::Mode::OUTPUT);
+    led_lfo.Init(daisy::seed::D29, false, SAMPLE_RATE );
     knob_handler->InitAll();
     button_handler->InitAll();
     InitComponents(SAMPLE_RATE, BLOCK_SIZE);
@@ -611,6 +619,9 @@ int main(void)
         }
         led_sweep.Write(button_handler->sweepToTuneState);
         led_bank.Write(test);
+
+
+        //Update the led to reflect the set value
 
         if(DEBUG)
         {


### PR DESCRIPTION
✨ Adiciona controle visual de LFO com LED

**Descrição**
Este PR introduz a funcionalidade de controle visual para o LFO utilizando um LED conectado ao pino D29, oferecendo feedback em tempo real da intensidade do LFO. As principais modificações incluem:

- Adição do objeto Led led_lfo à lista de componentes.

- Inicialização do LED do LFO em main(), utilizando led_lfo.Init(daisy::seed::D29, false, SAMPLE_RATE);.

- Controle do brilho do LED no AudioCallback(), proporcional ao valor do LFO modulado pelo envelope ((lfo_output.first * 0.5f + 0.5f) * adsr_output).

- Chamada de led_lfo.Update() por bloco de áudio para atualizar o estado do LED.

**Motivação**
A presença de um LED que reflete visualmente o comportamento do LFO facilita o debug e proporciona melhor usabilidade para performances ao vivo, permitindo visualizar o andamento da modulação mesmo sem áudio.

