### PR TITLE
#21 - adicionar região 'flat' no knob de sweep para que o sweep não atue 

### DIFF
--- a/dub.cpp
+++ b/dub.cpp
@@ -476,29 +476,38 @@ void AudioCallback(AudioHandle::InputBuffer  in,
         }
         else
         {
-            // When not pressed, modulate VCF freq based on envelope and sweep direction
-            float start_exp = cutoff_exponent;
-            float end_exp;
+            float base_exp = cutoff_exponent;
 
-            if(sweepVal < 0.5f) // Sweep goes up
-            {
-                end_exp = 1.0f; // VCF_MAX_FREQ exponent
-            }
-            else // Sweep goes down
-            {
-                end_exp = 0.0f; // VCF_MIN_FREQ exponent
-            }
+            // Map sweepVal ∈ [0,1] to [-1,1]
+            float direction = 2.0f * (sweepVal - 0.5f);
 
-            // Exponentially interpolate in the exponent domain
+            // Increase dead zone using a threshold (e.g. 0.2)
+            float threshold = 0.2f;
+
+            // Calculate sweep intensity: zero in center, max at extremes, smoothed
+            float abs_dir = fabsf(direction);
+            float intensity
+                = (abs_dir > threshold)
+                      ? powf((abs_dir - threshold) / (1.0f - threshold), 2.0f)
+                      : 0.0f;
+
+            // Compute target exponent:
+            // direction < 0 → freq goes up → end_exp = 1
+            // direction > 0 → freq goes down → end_exp = 0
+            float end_exp = 0.5f - 0.5f * direction;
+
+            // Blend start and end exponents modulated by ADSR and sweep intensity
             float sweep_exp
-                = start_exp + (end_exp - start_exp) * (1.0f - adsr_output);
+                = base_exp
+                  + (end_exp - base_exp) * (1.0f - adsr_output) * intensity;
 
-            // Apply the exponential mapping
+            // Final exponential frequency
             float cutoff
                 = VCF_MIN_FREQ * powf(VCF_MAX_FREQ / VCF_MIN_FREQ, sweep_exp);
 
             vcf->SetFreq(cutoff);
         }
+
 
         // Initial output from envelope
         output = adsr_output;


### PR DESCRIPTION
**📌 Descrição****
Este PR refatora a lógica de interpolação de frequência tanto no filtro (VCF) quanto no oscilador (VCO)  no uso da função sweep (botão SweepToTune), substituindo o antigo controle com if/else por uma função quadrática contínua que torna a transição mais suave, com zona morta central e comportamento progressivo nas extremidades. Os parâmetros da curva provavelmente serão alterados após QA, agora é apenas uma implementação lógica.