### PR TITLE
#51 - Baixar o limite inferior da frequência do corte do VCF

### DIFF
--- a/dub.h
+++ b/dub.h
@@ -25,7 +25,7 @@ using namespace daisysp;
 #define LFO_MAX_FREQ 20.0f
 
 #define VCF_FILTER OnePole::FILTER_MODE_LOW_PASS
-#define VCF_MIN_FREQ 120.0f
+#define VCF_MIN_FREQ 5.0f
 #define VCF_MAX_FREQ 15000.0f
 
 DaisySeed hw;

--- a/dub.h
+++ b/dub.h
@@ -25,7 +25,7 @@ using namespace daisysp;
 #define LFO_MAX_FREQ 20.0f
 
 #define VCF_FILTER OnePole::FILTER_MODE_LOW_PASS
-#define VCF_MIN_FREQ 5.0f
+#define VCF_MIN_FREQ 15.0f
 #define VCF_MAX_FREQ 15000.0f
 
 DaisySeed hw;


### PR DESCRIPTION
## Descrição

Esta PR diminui a macro `LFO_MIN_FREQ` de 120Hz para 5Hz. 

Quando o filtro está no mínimo, 5Hz é o suficiente para o som ficar quase inaudível (em um bom fone e bem alto, ainda é possível ouvir um pouco do som). Ao mesmo tempo, as cutoffs mais graves não comem tanto do knob. 

Essa diminuição vem pela discussão de que o filtro no mínimo deveria ocultar totalmente o som, para que seja possível matá-lo sem precisar tocar no knob de volume.

## Testagem

Veja se ainda há muito resquício de som quando o filtro está no mínimo. Se houver, posso diminuir ainda mais a cutoff.

## Issues relacionadas

Closes #51 