### PR TITLE
#53 - Alterar frequências mínima e máxima do VCO e testar comportamento do Depth

### DIFF
--- a/dub.h
+++ b/dub.h
@@ -8,8 +8,8 @@ using namespace daisysp;
 
 // Constants
 #define VCO_WAVEFORM Oscillator::WAVE_POLYBLEP_SQUARE
-#define VCO_MIN_FREQ 30.0f
-#define VCO_MAX_FREQ 9000.0f
+#define VCO_MIN_FREQ 32.703f // Corresponds to a midi C1
+#define VCO_MAX_FREQ 1046.5f // Corresponds to a midi C6
 
 #define ADSR_ATTACK_TIME 0.3f
 #define ADSR_DECAY_TIME 0.1f


### PR DESCRIPTION
## Descrição

Esta PR muda as macros `VCO_MIN_FREQ` e `VCO_MAX_FREQ`.

`VCO_MIN_FREQ`: 30Hz -> 32.703Hz (midi C1)
`VCO_MAX_FREQ`: 9000Hz -> 1046.5Hz (midi C6)

O intervalo de frequência foi reduzido para deixar o som do synth menos ardido. Por consequência, o som com depth grande também ficou menos ardido.

As extremidades da frequência do VCO foram convertidas para notas dó, ao invés de manter números arbitrários como antes.

## Testagem

Mexa nos knobs de tune e depth. Teste também no modo sweep to tune. Verifique se o som está mais confortável de se ouvir.

## Issues relacionadas

Closes #53 