### PR TITLE
#33 -  Arrumar lógica do bank select para atuar apenas no próximo acionamento após chaveamento

### DIFF
--- a/dub.cpp
+++ b/dub.cpp
@@ -334,14 +334,15 @@ void Lfo::ResetPhaseAll()
 
 std::pair<float, float> Lfo::ProcessAll()
 {
-    int  index = button_handler->LastIndex;
-    bool bankB = button_handler->bankSelectState;
+    int index = button_handler->LastIndex;
+    // Use o banco atualmente ativo
+    bool bankB = button_handler->currentBankState;
 
     UpdateWaveforms(index, bankB);
     float lfo_val = MixLfoSignals(index, bankB);
 
-    float scaled_lfo = lfo_val * DepthValue; // Scale LFO to [-depth,+depth]
-    float modsig     = 0.5f + scaled_lfo;    // Add DC offset
+    float scaled_lfo = lfo_val * DepthValue;
+    float modsig     = 0.5f + scaled_lfo;
 
     return std::make_pair(lfo_val, modsig);
 }
@@ -455,6 +456,7 @@ void AudioCallback(AudioHandle::InputBuffer  in,
         if(triggered)
         {
             envelope->Retrigger();
+            button_handler->currentBankState = button_handler->bankSelectState;
         }
 
         // Set and process envelope
@@ -623,7 +625,8 @@ int main(void)
             test = !test;
         }
         led_sweep.Write(button_handler->sweepToTuneState);
-        led_bank.Write(test);
+        led_bank.Write(
+            button_handler->bankSelectState); // Mostra o banco pendente
 
 
         //Update the led to reflect the set value

--- a/dub.h
+++ b/dub.h
@@ -230,15 +230,16 @@ class ButtonHandler
         this->LastIndex        = 0;
         this->bankSelectState  = false;
         this->sweepToTuneState = false;
+        this->currentBankState = false; // Banco atualmente ativo
     }
 
     // There are 4 trigger buttons.
     // Each one has 3 states (true of false): Triggered, Pressed, Released.
-    bool triggersStates[4][3];
-    bool bankSelectState;
-    bool sweepToTuneState;
-    int  LastIndex;
-
+    bool         triggersStates[4][3];
+    bool         bankSelectState;
+    bool         sweepToTuneState;
+    int          LastIndex;
+    bool         currentBankState;
     virtual void InitAll();
     virtual void DebounceAll();
     virtual void UpdateAll();


### PR DESCRIPTION
**Mudança**
Separamos o banco selecionado (bankSelectState) do banco ativo (currentBankState).

**Lógica**
bankSelectState muda no botão.

currentBankState só muda quando há trigger.

**Impacto**
Evita que a troca de banco afete sons em andamento. O novo banco só entra em vigor no próximo trigger.