### PR TITLE
#55 - Arrumar lógica do sweep to tune

### DIFF
--- a/dub.cpp
+++ b/dub.cpp
@@ -110,33 +110,27 @@ void ButtonHandlerDaisy::DebounceAll()
 
 void ButtonHandlerDaisy::UpdateAll()
 {
-    // Update trigger states with latch mechanism
     for(int i = 0; i < 4; i++)
     {
-        // Only set triggered to true, don't clear it here (latch mechanism)
         if(this->triggers[i].RisingEdge())
         {
-            this->triggersStates[i][0] = true; // Latch the trigger
+            this->triggersStates[i][0] = true;
             this->LastIndex            = i;
         }
-
-        // Trigger is being pressed
         this->triggersStates[i][1] = this->triggers[i].Pressed();
-
-        // Trigger is released
         this->triggersStates[i][2] = this->triggers[i].FallingEdge();
     }
 
-    // Update bank select and sweep to tune states
     if(this->bankSelect.RisingEdge())
     {
         this->bankSelectState = !this->bankSelectState;
     }
     if(this->sweepToTune.RisingEdge())
     {
-        this->sweepToTuneState = !this->sweepToTuneState;
+        this->sweepToTuneState = !this->sweepToTuneState; // só o pendente
     }
 }
+
 // ButtonHandler functions
 
 
@@ -455,6 +449,10 @@ void AudioCallback(AudioHandle::InputBuffer  in,
         if(triggered)
         {
             envelope->Retrigger();
+            // Aplicar mudanças pendentes
+            button_handler->currentBankState = button_handler->bankSelectState;
+            button_handler->sweepToTuneActive
+                = button_handler->sweepToTuneState;
         }
 
         // Set and process envelope
@@ -546,7 +544,7 @@ void AudioCallback(AudioHandle::InputBuffer  in,
             = VCO_MIN_FREQ * powf(VCO_MAX_FREQ / VCO_MIN_FREQ, tune_with_mod);
 
         // Optional sweep modulation mapped to VCO frequency
-        if(button_handler->sweepToTuneState)
+        if(button_handler->sweepToTuneActive)
         {
             float direction = 2.0f * (sweepVal - 0.5f);
             float threshold = 0.2f;

--- a/dub.h
+++ b/dub.h
@@ -237,6 +237,7 @@ class ButtonHandler
     bool triggersStates[4][3];
     bool bankSelectState;
     bool sweepToTuneState;
+    bool sweepToTuneActive;
     int  LastIndex;
 
     virtual void InitAll();
@@ -247,9 +248,23 @@ class ButtonHandler
 class ButtonHandlerDaisy : public ButtonHandler
 {
   public:
+    ButtonHandlerDaisy()
+    {
+        this->bankSelectState   = false; // já existe
+        this->currentBankState  = false; // já existe
+        this->sweepToTuneState  = false; // já existe (pendente)
+        this->sweepToTuneActive = false; // novo - estado real (ativo)
+    }
+
+
     Switch triggers[4];
     Switch bankSelect;
     Switch sweepToTune;
+
+    bool bankSelectState;
+    bool currentBankState;
+    bool sweepToTuneState;
+    bool sweepToTuneActive;
 
     void InitAll() override;
     void DebounceAll() override;


### PR DESCRIPTION
**Mudança**
Separamos o estado pendente (sweepToTuneState) do estado ativo (sweepToTuneActive).

**Lógica**
O botão atualiza sweepToTuneState, que representa a intenção do usuário.

O valor só é copiado para sweepToTuneActive ao pressionar um trigger.

**Impacto**
Evita mudanças abruptas na afinação enquanto um som está em andamento. A nova configuração de SweepToTune só afeta o som no próximo disparo (trigger).

**Observações**
O LED de SweepToTune continua indicando o estado pendente (próximo valor).

Comportamento idêntico ao aplicado anteriormente para a troca de banco.

Closes #55