### PR TITLE
#30 -  Forma do LFO fica travada no último botão apertado

### DIFF
--- a/dub.h
+++ b/dub.h
@@ -124,15 +124,22 @@ class Lfo
             osc_harm[i].Init(sample_rate);
             osc_harm[i].SetWaveform(Oscillator::WAVE_SIN);
         }
+        this->prevIndex    = -1;
+        this->currIndex    = -1;
+        this->fadeProgress = 1.0f;                        // 1.0 significa fim
+        this->fadeRate     = 1.0f / (sample_rate * 0.1f); // 100ms fade
     }
 
 
-    float      DepthValue;
-    float      RateValue;
-    Oscillator osc[4];
-    Oscillator osc_harm[4];
-    float      values[5][2]; // oscillator value and modsig value
-
+    float                   DepthValue;
+    float                   RateValue;
+    Oscillator              osc[4];
+    Oscillator              osc_harm[4];
+    float                   values[5][2]; // oscillator value and modsig value
+    int                     prevIndex;
+    int                     currIndex;
+    float                   fadeProgress;
+    float                   fadeRate;
     void                    Init();
     void                    UpdateWaveforms(int index, bool bankB);
     float                   MixLfoSignals(int index, bool bankB);


### PR DESCRIPTION
### 🌀 Crossfade entre formas de onda LFO
- Quando um novo botão é pressionado, o LFO realiza um crossfade (lerp) suave da forma de onda anterior para a nova.
- Duração do crossfade: ~100 ms.
- Evita saltos abruptos ao trocar de modulação, resultando em transições sonoras mais suaves e musicais.

### 🎛️ Estrutura de fila para botões
- A estrutura `press_stack` armazena a ordem em que os botões são pressionados.
- O campo `LastIndex` é sempre atualizado com o último botão pressionado e mantém esse valor até que ele seja solto.
- Ao soltar um botão, `LastIndex` retorna automaticamente para o botão anterior ainda pressionado, garantindo continuidade no controle da forma de onda.

Closes #30 

