### PR TITLE
 #54 - Remover click quando filtro no mínimo e algum decay

### DIFF
--- a/dub.cpp
+++ b/dub.cpp
@@ -197,12 +197,6 @@ float DecayEnvelope::Process(bool gate)
     return this->EnvelopeValue;
 }
 
-void DecayEnvelope::Retrigger()
-{
-    envelope.Retrigger(true);
-}
-// DecayEnvelope functions
-
 
 // Triggers functions
 bool Triggers::Triggered()
@@ -270,13 +264,6 @@ float Sweep::Process(bool gate)
     this->EnvelopeValue = this->envelope.Process(gate);
     return this->EnvelopeValue;
 }
-
-void Sweep::Retrigger()
-{
-    envelope.Retrigger(true);
-}
-// Sweep functions
-
 
 // --- Lfo functions ---
 void Lfo::UpdateWaveforms(int index, bool bankB)
@@ -502,7 +489,6 @@ void AudioCallback(AudioHandle::InputBuffer  in,
 {
     if(shouldApplyToggles)
     {
-        envelope->Retrigger();
         lfo->ResetPhaseAll();
 
         button_handler->currentBankState  = button_handler->bankSelectState;
@@ -523,7 +509,6 @@ void AudioCallback(AudioHandle::InputBuffer  in,
         // Reset envelope and LFO on trigger
         if(shouldApplyToggles)
         {
-            envelope->Retrigger();
             lfo->ResetPhaseAll();
 
             // Aplicar mudanças pendentes

--- a/dub.h
+++ b/dub.h
@@ -61,7 +61,6 @@ class DecayEnvelope
 
     void  SetReleaseTime(float time);
     float Process(bool gate);
-    void  Retrigger();
 };
 // DecayEnvelope
 
@@ -91,7 +90,6 @@ class Sweep
 
     void  SetReleaseTime(float time);
     float Process(bool gate);
-    void  Retrigger();
 };
 // Sweep
 


### PR DESCRIPTION
Este PR remove a lógica de Retrigger do envelope ao trocar de trigger enquanto outro está pressionado.
O objetivo é eliminar os clicks audíveis que ocorriam durante a troca de triggers.

Aqui tem uma imagem da documentação que mostra que realmente com retrigger o audio clica
<img width="432" height="237" alt="image" src="https://github.com/user-attachments/assets/f86afa4a-0753-4883-bf88-f8ffb633a62e" />

Closes #54 
