### PR TITLE
#56 - Refatorar cálculo do depth_exp usando a função pow10f ao invés de powf

### DIFF
--- a/dub.cpp
+++ b/dub.cpp
@@ -594,7 +594,7 @@ void AudioCallback(AudioHandle::InputBuffer  in,
 
         // --- LFO processing ---
         lfo->SetFreqAll(lfo->RateValue);
-        float depth_exp = powf(10.f, (lfo->DepthValue - 1.0f));
+        float depth_exp = pow10f(lfo->DepthValue - 1.0f);
         lfo->SetAmpAll(depth_exp);
         lfo_output = lfo->ProcessAll();
 


### PR DESCRIPTION
## Descrição

[ :zap: ] Esta PR apenas refatora uma linha de código: o cálculo da variável `depth_exp`.

Antes:
```cpp
float depth_exp = powf(10.f, (lfo->DepthValue - 1.0f));
```
Depois:
```cpp
float depth_exp = pow10f(lfo->DepthValue - 1.0f);
```
De acordo com a documentação da função `pow10f`,
> No approximation, pow10f(x) gives a 90% speed increase over powf(10.f, x)

## Testagem

Teste se o knob de Depth está funcionando.

## Issues relacionadas

Closes #56 