### PR TITLE
#50 Desacoplar a curva da cutoff do VCF com trigger pressionado da curva da intensidade do sweep com trigger solto

### DIFF
--- a/dub.cpp
+++ b/dub.cpp
@@ -446,8 +446,21 @@ void Vcf::SetFreq(float freq)
 
 void Vcf::UpdateCutoffPressed(float sweepValue)
 {
+    // Map the sweep value to a piecewise linear interpolation
+    // 0%  to 50%  -> 0%  to 75%
+    // 50% to 100% -> 75% to 100%
+    if(sweepValue <= 0.5f)
+    {
+        this->CutoffExponent = (sweepValue / 0.5f) * 0.75f;
+    }
+    else
+    {
+        this->CutoffExponent = 0.75f + ((sweepValue - 0.5f) / 0.5f) * 0.25f;
+    }
+
     this->CutoffFreq
-        = VCF_MIN_FREQ * powf(VCF_MAX_FREQ / VCF_MIN_FREQ, sweepValue);
+        = VCF_MIN_FREQ
+          * powf(VCF_MAX_FREQ / VCF_MIN_FREQ, this->CutoffExponent);
     this->SetFreq(this->CutoffFreq);
 }
 
@@ -572,7 +585,8 @@ void AudioCallback(AudioHandle::InputBuffer  in,
         }
         else
         {
-            vcf->CutoffFreq = sweep->UpdateCutoffFreq(sweepVal, vcf, adsr_output);
+            vcf->CutoffFreq
+                = sweep->UpdateCutoffFreq(sweepVal, vcf, adsr_output);
             vcf->SetFreq(vcf->CutoffFreq);
         }
 

--- a/dub.cpp
+++ b/dub.cpp
@@ -527,17 +527,14 @@ void AudioCallback(AudioHandle::InputBuffer  in,
         adsr_output = envelope->Process(pressed);
 
         // --- Filter frequency (VCF) logic ---
-        // static float cutoff_exponent = 0.0f;
         float cutoff_exponent = sweepVal;
 
         if(pressed)
         {
             // When pressed, control VCF freq with sweep knob using exponential curve
-            // cutoff_exponent = powf(sweepVal, 0.5f);
             sweep->CutoffFreq
                 = VCF_MIN_FREQ
                   * powf(VCF_MAX_FREQ / VCF_MIN_FREQ, cutoff_exponent);
-            vcf->SetFreq(sweep->CutoffFreq);
         }
         else
         {
@@ -567,11 +564,11 @@ void AudioCallback(AudioHandle::InputBuffer  in,
                   + (end_exp - base_exp) * (1.0f - adsr_output) * intensity;
 
             // Final exponential frequency
-            float cutoff
+            sweep->CutoffFreq
                 = VCF_MIN_FREQ * powf(VCF_MAX_FREQ / VCF_MIN_FREQ, sweep_exp);
-
-            vcf->SetFreq(cutoff);
         }
+
+        vcf->SetFreq(sweep->CutoffFreq);
 
 
         // Initial output from envelope

--- a/dub.cpp
+++ b/dub.cpp
@@ -265,6 +265,38 @@ float Sweep::Process(bool gate)
     return this->EnvelopeValue;
 }
 
+float Sweep::UpdateCutoffFreq(float sweepValue, Vcf* vcf, float adsrOutput)
+{
+    float base_exp = vcf->CutoffExponent;
+
+    // Map sweepVal from [0,1] to [-1,1]
+    float direction = 2.0f * (sweepValue - 0.5f);
+
+    // Increase dead zone using a threshold
+    // Must be between [0,1]
+    float threshold = 0.2f;
+
+    // Calculate sweep intensity:
+    // zero in center, max at extremes, smoothed
+    float abs_dir = fabsf(direction);
+    float intensity
+        = (abs_dir > threshold)
+              ? powf((abs_dir - threshold) / (1.0f - threshold), 2.0f)
+              : 0.0f;
+
+    // Compute target exponent:
+    // direction < 0 → freq goes up   → end_exp = 1
+    // direction > 0 → freq goes down → end_exp = 0
+    float end_exp = 0.5f - 0.5f * direction;
+
+    // Blend start and end exponents modulated by ADSR and sweep intensity
+    float sweep_exp
+        = base_exp + (end_exp - base_exp) * (1.0f - adsrOutput) * intensity;
+
+    // Final exponential frequency
+    return VCF_MIN_FREQ * powf(VCF_MAX_FREQ / VCF_MIN_FREQ, sweep_exp);
+}
+
 // --- Lfo functions ---
 void Lfo::UpdateWaveforms(int index, bool bankB)
 {
@@ -412,6 +444,13 @@ void Vcf::SetFreq(float freq)
     this->filter.SetFreq(limited_freq);
 }
 
+void Vcf::UpdateCutoffPressed(float sweepValue)
+{
+    this->CutoffFreq
+        = VCF_MIN_FREQ * powf(VCF_MAX_FREQ / VCF_MIN_FREQ, sweepValue);
+    this->SetFreq(this->CutoffFreq);
+}
+
 float Vcf::Process(float in)
 {
     this->filter.Process(in);
@@ -527,48 +566,15 @@ void AudioCallback(AudioHandle::InputBuffer  in,
         adsr_output = envelope->Process(pressed);
 
         // --- Filter frequency (VCF) logic ---
-        float cutoff_exponent = sweepVal;
-
         if(pressed)
         {
-            // When pressed, control VCF freq with sweep knob using exponential curve
-            vcf->CutoffFreq
-                = VCF_MIN_FREQ
-                  * powf(VCF_MAX_FREQ / VCF_MIN_FREQ, cutoff_exponent);
+            vcf->UpdateCutoffPressed(sweepVal);
         }
         else
         {
-            float base_exp = cutoff_exponent;
-
-            // Map sweepVal ∈ [0,1] to [-1,1]
-            float direction = 2.0f * (sweepVal - 0.5f);
-
-            // Increase dead zone using a threshold (e.g. 0.2)
-            float threshold = 0.2f;
-
-            // Calculate sweep intensity: zero in center, max at extremes, smoothed
-            float abs_dir = fabsf(direction);
-            float intensity
-                = (abs_dir > threshold)
-                      ? powf((abs_dir - threshold) / (1.0f - threshold), 2.0f)
-                      : 0.0f;
-
-            // Compute target exponent:
-            // direction < 0 → freq goes up → end_exp = 1
-            // direction > 0 → freq goes down → end_exp = 0
-            float end_exp = 0.5f - 0.5f * direction;
-
-            // Blend start and end exponents modulated by ADSR and sweep intensity
-            float sweep_exp
-                = base_exp
-                  + (end_exp - base_exp) * (1.0f - adsr_output) * intensity;
-
-            // Final exponential frequency
-            vcf->CutoffFreq
-                = VCF_MIN_FREQ * powf(VCF_MAX_FREQ / VCF_MIN_FREQ, sweep_exp);
+            vcf->CutoffFreq = sweep->UpdateCutoffFreq(sweepVal, vcf, adsr_output);
+            vcf->SetFreq(vcf->CutoffFreq);
         }
-
-        vcf->SetFreq(vcf->CutoffFreq);
 
 
         // Initial output from envelope

--- a/dub.cpp
+++ b/dub.cpp
@@ -532,7 +532,7 @@ void AudioCallback(AudioHandle::InputBuffer  in,
         if(pressed)
         {
             // When pressed, control VCF freq with sweep knob using exponential curve
-            sweep->CutoffFreq
+            vcf->CutoffFreq
                 = VCF_MIN_FREQ
                   * powf(VCF_MAX_FREQ / VCF_MIN_FREQ, cutoff_exponent);
         }
@@ -564,11 +564,11 @@ void AudioCallback(AudioHandle::InputBuffer  in,
                   + (end_exp - base_exp) * (1.0f - adsr_output) * intensity;
 
             // Final exponential frequency
-            sweep->CutoffFreq
+            vcf->CutoffFreq
                 = VCF_MIN_FREQ * powf(VCF_MAX_FREQ / VCF_MIN_FREQ, sweep_exp);
         }
 
-        vcf->SetFreq(sweep->CutoffFreq);
+        vcf->SetFreq(vcf->CutoffFreq);
 
 
         // Initial output from envelope

--- a/dub.h
+++ b/dub.h
@@ -82,7 +82,6 @@ class Sweep
 
     float SweepValue; // Knob value from 0.0f to 1.0f
     bool  IsSweepToTuneActive;
-    float CutoffFreq;
 
     Adsr  envelope;
     float ReleaseValue;  // Knob value from 0.0f to 1.0f
@@ -179,10 +178,12 @@ class Vcf
         this->filter.Init(sample_rate);
         this->filter.SetDrive(100.0f);
         this->filter.SetRes(0.95f);
+        this->CutoffFreq = VCF_MIN_FREQ;
     }
 
     Svf filter;
     //OnePole filter;
+    float CutoffFreq;
 
     void  SetFreq(float freq);
     float Process(float in);

--- a/dub.h
+++ b/dub.h
@@ -65,7 +65,6 @@ class DecayEnvelope
 // DecayEnvelope
 
 
-
 // Triggers
 class Triggers
 {
@@ -166,7 +165,6 @@ class Vcf
 // Vcf
 
 
-
 // Sweep
 class Sweep
 {
@@ -194,7 +192,6 @@ class Sweep
     float UpdateCutoffFreq(float sweepValue, Vcf* vcf, float adsrOutput);
 };
 // Sweep
-
 
 
 // OutAmp

--- a/dub.h
+++ b/dub.h
@@ -65,33 +65,6 @@ class DecayEnvelope
 // DecayEnvelope
 
 
-// Sweep
-class Sweep
-{
-  public:
-    Sweep(int sample_rate, int block_size)
-    {
-        this->SweepValue          = 0.0f;
-        this->IsSweepToTuneActive = false;
-        this->envelope.Init(sample_rate, block_size);
-        this->envelope.SetTime(ADSR_SEG_ATTACK, ADSR_ATTACK_TIME);
-        this->envelope.SetTime(ADSR_SEG_DECAY, ADSR_DECAY_TIME);
-        this->envelope.SetTime(ADSR_SEG_RELEASE, ADSR_RELEASE_TIME);
-        this->envelope.SetSustainLevel(ADSR_SUSTAIN_LEVEL);
-    }
-
-    float SweepValue; // Knob value from 0.0f to 1.0f
-    bool  IsSweepToTuneActive;
-
-    Adsr  envelope;
-    float ReleaseValue;  // Knob value from 0.0f to 1.0f
-    float EnvelopeValue; // Current envelope value from 0.0f to 1.0f
-
-    void  SetReleaseTime(float time);
-    float Process(bool gate);
-};
-// Sweep
-
 
 // Triggers
 class Triggers
@@ -184,11 +157,44 @@ class Vcf
     Svf filter;
     //OnePole filter;
     float CutoffFreq;
+    float CutoffExponent;
 
     void  SetFreq(float freq);
+    void  UpdateCutoffPressed(float sweepValue);
     float Process(float in);
 };
 // Vcf
+
+
+
+// Sweep
+class Sweep
+{
+  public:
+    Sweep(int sample_rate, int block_size)
+    {
+        this->SweepValue          = 0.0f;
+        this->IsSweepToTuneActive = false;
+        this->envelope.Init(sample_rate, block_size);
+        this->envelope.SetTime(ADSR_SEG_ATTACK, ADSR_ATTACK_TIME);
+        this->envelope.SetTime(ADSR_SEG_DECAY, ADSR_DECAY_TIME);
+        this->envelope.SetTime(ADSR_SEG_RELEASE, ADSR_RELEASE_TIME);
+        this->envelope.SetSustainLevel(ADSR_SUSTAIN_LEVEL);
+    }
+
+    float SweepValue; // Knob value from 0.0f to 1.0f
+    bool  IsSweepToTuneActive;
+
+    Adsr  envelope;
+    float ReleaseValue;  // Knob value from 0.0f to 1.0f
+    float EnvelopeValue; // Current envelope value from 0.0f to 1.0f
+
+    void  SetReleaseTime(float time);
+    float Process(bool gate);
+    float UpdateCutoffFreq(float sweepValue, Vcf* vcf, float adsrOutput);
+};
+// Sweep
+
 
 
 // OutAmp


### PR DESCRIPTION
## Descrição

Esta PR:
- Aprimora as variáveis das classes Sweep e Vcf;
- Encapsula o mapeamento da cutoff com trigger pressionado para a classe `Vcf::UpdateCutoffPressed()`;
- Encapsula o mapeamento da cutoff com trigger solto para a classe `Sweep::UpdateCutoffFreq()`;
- Aprimora o mapeamento antigo da cutoff com trigger pressionado, convertendo o mapeamento do expoente para um mapeamento linear por partes do expoente.

## Testagem

Compare o comportamento da cutoff manipulando o knob Sweep tanto com a implementação antiga quanto com a implementação nova.

Cheque se o knob está mais agradável.

## Issues relacionadas

Closes #50 