### PR TITLE
#84 - Encapsular deadzone como constante na classe Sweep (e diminuir seu valor)

### DIFF
--- a/dub.cpp
+++ b/dub.cpp
@@ -272,16 +272,13 @@ float Sweep::UpdateCutoffFreq(float sweepValue, Vcf* vcf, float adsrOutput)
     // Map sweepVal from [0,1] to [-1,1]
     float direction = 2.0f * (sweepValue - 0.5f);
 
-    // Increase dead zone using a threshold
-    // Must be between [0,1]
-    float threshold = 0.2f;
-
-    // Calculate sweep intensity:
+    // Calculate sweep intensity with deadzone:
     // zero in center, max at extremes, smoothed
     float abs_dir = fabsf(direction);
     float intensity
-        = (abs_dir > threshold)
-              ? powf((abs_dir - threshold) / (1.0f - threshold), 2.0f)
+        = (abs_dir > this->threshold)
+              ? powf((abs_dir - this->threshold) / (1.0f - this->threshold),
+                     2.0f)
               : 0.0f;
 
     // Compute target exponent:
@@ -621,12 +618,12 @@ void AudioCallback(AudioHandle::InputBuffer  in,
         if(button_handler->sweepToTuneActive)
         {
             float direction = 2.0f * (sweepVal - 0.5f);
-            float threshold = 0.2f;
             float abs_dir   = fabsf(direction);
-            float intensity
-                = (abs_dir > threshold)
-                      ? powf((abs_dir - threshold) / (1.0f - threshold), 2.0f)
-                      : 0.0f;
+            float intensity = (abs_dir > sweep->threshold)
+                                  ? powf((abs_dir - sweep->threshold)
+                                             / (1.0f - sweep->threshold),
+                                         2.0f)
+                                  : 0.0f;
 
             float end_exp   = 0.5f - 0.5f * direction;
             float sweep_exp = tune_with_mod

--- a/dub.h
+++ b/dub.h
@@ -169,7 +169,7 @@ class Vcf
 class Sweep
 {
   public:
-    Sweep(int sample_rate, int block_size)
+    Sweep(int sample_rate, int block_size) : threshold(0.1f)
     {
         this->SweepValue          = 0.0f;
         this->IsSweepToTuneActive = false;
@@ -180,8 +180,9 @@ class Sweep
         this->envelope.SetSustainLevel(ADSR_SUSTAIN_LEVEL);
     }
 
-    float SweepValue; // Knob value from 0.0f to 1.0f
-    bool  IsSweepToTuneActive;
+    float       SweepValue; // Knob value from 0.0f to 1.0f
+    bool        IsSweepToTuneActive;
+    const float threshold; // Sweep deadzone threshold (0-1)
 
     Adsr  envelope;
     float ReleaseValue;  // Knob value from 0.0f to 1.0f


### PR DESCRIPTION
## Descrição

Esta PR refatora a classe Sweep para encapsular o valor de threshold usado para a deadzone do knob de sweep como uma constante, ao invés de deixar várias variáveis com a mesma função espalhadas pelo código.

Além disso, o valor de threshold foi reduzido de 0.2 para 0.1, deixando o efeito de sweep mais sensível.

Closes #84 

## Testagem

Teste o knob de sweep próximo de 50% com o sweep-to-tune desligado e também ligado.