### PR TITLE
#85 - Corrigir as curvas de sweep do filtro e do pitch

### DIFF
--- a/dub.h
+++ b/dub.h
@@ -189,6 +189,8 @@ class Sweep
 
     void  SetReleaseTime(float time);
     float Process(bool gate);
+    float CalculateFilterIntensity(float sweepValue);
+    float CalculateVcoIntensity(float sweepValue);
     float UpdateCutoffFreq(float sweepValue, Vcf* vcf, float adsrOutput);
 };
 // Sweep


### PR DESCRIPTION
## Descrição

Essa PR encapsula o cálculo da intensidade do sweep do filtro e do pitch (quando sweep-to-tune está ligado) em funções da classe `Sweep`.

A intensidade do filtro foi diferenciada para 2 casos: quando a cutoff está abaixo do threshold e quando ela está acima.
- Quando a cutoff está abaixo da threshold (filtro mais fechado), o filtro abre rapidamente. Assemelha-se a um movimento de ataque.
- Quando a cutoff está acima da threshold (filtro mais aberto), o filtro fecha lentamente. Assemelha-se a um movimento de decaimento.

A intensidade do pitch foi suavizada, pois estava rápido demais.