### PR TITLE
#84 - Encapsular deadzone como constante na classe Sweep (e diminuir seu valor)

### DIFF
--- a/dub.cpp
+++ b/dub.cpp
@@ -273,7 +273,7 @@ float Sweep::CalculateFilterIntensity(float sweepValue)
     float abs_dir   = fabsf(direction);
 
     // Dead zone threshold
-    float threshold = 0.2f;
+    float threshold = DEADZONE_HALF_WIDTH;
     float intensity = 0.0f;
 
     // Assymetrical curve
@@ -301,7 +301,7 @@ float Sweep::CalculateVcoIntensity(float sweepValue)
     float direction = 2.0f * (sweepValue - 0.5f);
     float abs_dir   = fabsf(direction);
 
-    float threshold = 0.2f;
+    float threshold = DEADZONE_HALF_WIDTH;
     float intensity = 0.f;
 
     // Calculate sweep intensity for VCO:

--- a/dub.h
+++ b/dub.h
@@ -201,7 +201,7 @@ class Sweep
     float UpdateCutoffFreq(float sweepValue, Vcf* vcf, float adsrOutput);
 
   private:
-    static constexpr float DEADZONE_HALF_WIDTH = 0.2f; // Half-width of deadzone on each side of center
+    static constexpr float DEADZONE_HALF_WIDTH = 0.1f; // Half-width of deadzone on each side of center
 };
 // Sweep
 

--- a/dub.h
+++ b/dub.h
@@ -199,6 +199,9 @@ class Sweep
     float CalculateFilterIntensity(float sweepValue);
     float CalculateVcoIntensity(float sweepValue);
     float UpdateCutoffFreq(float sweepValue, Vcf* vcf, float adsrOutput);
+
+  private:
+    static constexpr float DEADZONE_HALF_WIDTH = 0.2f; // Half-width of deadzone on each side of center
 };
 // Sweep
 


### PR DESCRIPTION
## Descrição

Esta PR refatora o código para encapsular o valor da deadzone na classe Sweep, substituindo os números mágicos por uma variável com nome `DEADZONE_HALF_WIDTH`. Após a refatoração, diminui a deadzone de `0.2f` para `0.1f`. 