### PR TITLE
#92 - Aumentar a cutoff para o knob Sweep em 50%

### DIFF
--- a/dub.cpp
+++ b/dub.cpp
@@ -524,20 +524,22 @@ void Vcf::UpdateCutoffPressed(float sweepValue)
     // 0% to 50% knob  -> 0% to firstHalfMax% frequency range (exponential)
     // 50% to 100% knob -> firstHalfMax% to 100% frequency range (exponential)
     const float firstHalfMax = 0.9f;
-    
+
     if(sweepValue <= 0.5f)
     {
         // First half: Exponential mapping to firstHalfMax of range
-        float normalized = sweepValue * 2.f;  // 0.0 to 1.0
-        const float expCurve = 0.5f;  // 0.1 makes the curve more linear in the end
+        float       normalized = sweepValue * 2.f; // 0.0 to 1.0
+        const float expCurve
+            = 0.5f; // 0.1 makes the curve more linear in the end
         this->CutoffExponent = firstHalfMax * powf(normalized, expCurve);
     }
     else
     {
         // Second half: Power function for smooth compression
-        float normalized = (sweepValue - 0.5f) * 2.f;  // 0.0 to 1.0
+        float normalized = (sweepValue - 0.5f) * 2.f; // 0.0 to 1.0
         float remaining  = 1.0f - firstHalfMax;
-        this->CutoffExponent = firstHalfMax + remaining * powf(normalized, SWEEP_CURVE_POWER);
+        this->CutoffExponent
+            = firstHalfMax + remaining * powf(normalized, SWEEP_CURVE_POWER);
     }
 
     this->CutoffFreq

--- a/dub.cpp
+++ b/dub.cpp
@@ -520,16 +520,24 @@ void Vcf::SetFreq(float freq)
 
 void Vcf::UpdateCutoffPressed(float sweepValue)
 {
-    // Map the sweep value to a piecewise linear interpolation
-    // 0%  to 50%  -> 0%  to 75%
-    // 50% to 100% -> 75% to 100%
+    // Map the sweep value to achieve:
+    // 0% to 50% knob  -> 0% to firstHalfMax% frequency range (exponential)
+    // 50% to 100% knob -> firstHalfMax% to 100% frequency range (exponential)
+    const float firstHalfMax = 0.9f;
+    
     if(sweepValue <= 0.5f)
     {
-        this->CutoffExponent = (sweepValue / 0.5f) * 0.75f;
+        // First half: Exponential mapping to firstHalfMax of range
+        float normalized = sweepValue * 2.f;  // 0.0 to 1.0
+        const float expCurve = 0.5f;  // 0.1 makes the curve more linear in the end
+        this->CutoffExponent = firstHalfMax * powf(normalized, expCurve);
     }
     else
     {
-        this->CutoffExponent = 0.75f + ((sweepValue - 0.5f) / 0.5f) * 0.25f;
+        // Second half: Power function for smooth compression
+        float normalized = (sweepValue - 0.5f) * 2.f;  // 0.0 to 1.0
+        float remaining  = 1.0f - firstHalfMax;
+        this->CutoffExponent = firstHalfMax + remaining * powf(normalized, SWEEP_CURVE_POWER);
     }
 
     this->CutoffFreq

--- a/dub.h
+++ b/dub.h
@@ -28,6 +28,7 @@ using namespace daisysp;
 #define VCF_FILTER OnePole::FILTER_MODE_LOW_PASS
 #define VCF_MIN_FREQ 15.0f
 #define VCF_MAX_FREQ 15000.0f
+#define SWEEP_CURVE_POWER 3.0f
 
 DaisySeed hw;
 


### PR DESCRIPTION
## Descrição

Esta PR muda o mapeamento da frequência de corte quando algum trigger está sendo pressionado. Agora, o knob de sweep entre 0% a 50% cobre 90% do espectro cheio do filtro (o espectro cheio é o intervalo 15Hz até 15kHz).

Isso resulta em um filtro menos fechado quando o knob de sweep está no ponto neutro (50%).